### PR TITLE
SOPORTE: ESTILOS PARA LA LISTA DE PROVEEDORES Y BUSQUEDA CON CAMPOS OPCIONALES EN LOS SELECTORES DE CLIENTE Y PROVEEDORES

### DIFF
--- a/src/app/aurora/components/sidebar/aurora-contable/tienda/comprar/comprar.component.css
+++ b/src/app/aurora/components/sidebar/aurora-contable/tienda/comprar/comprar.component.css
@@ -1,0 +1,12 @@
+.custom-select {
+    position: relative;
+}
+
+.dropdown-menu {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.form-control {
+    margin-bottom: 10px;
+}

--- a/src/app/aurora/components/sidebar/aurora-contable/tienda/comprar/comprar.component.ts
+++ b/src/app/aurora/components/sidebar/aurora-contable/tienda/comprar/comprar.component.ts
@@ -728,7 +728,7 @@ export class ComprarComponent implements OnInit {
       let filter = true;
       if (this.searchProveedores) {
         filter = proveedor.proveedor.toLowerCase().includes(this.searchProveedores.toLowerCase()) ||
-          proveedor.numeroIdentificacion.toLowerCase().includes(this.searchProveedores.toLowerCase());
+          proveedor.numeroIdentificacion?.toLowerCase().includes(this.searchProveedores.toLowerCase());
       }
       return filter;
     });

--- a/src/app/aurora/components/sidebar/aurora-contable/tienda/vender/vender.component.ts
+++ b/src/app/aurora/components/sidebar/aurora-contable/tienda/vender/vender.component.ts
@@ -728,8 +728,8 @@ export class VenderComponent implements OnInit {
       let filter = true;
       if (this.searchClientes) {
         filter = cliente.nombres.toLowerCase().includes(this.searchClientes.toLowerCase()) ||
-          cliente.apellidos.toLowerCase().includes(this.searchClientes.toLowerCase()) ||
-          cliente.numeroIdentificacion.toLowerCase().includes(this.searchClientes.toLowerCase());
+          cliente.apellidos?.toLowerCase().includes(this.searchClientes.toLowerCase()) ||
+          cliente.numeroIdentificacion?.toLowerCase().includes(this.searchClientes.toLowerCase());
       }
       return filter;
     });


### PR DESCRIPTION
Se agrego el estilo css para que funcione correctamente la lista de selección de proveedores en el submódulo de compra y se marco como opcional la busqueda por número de identificación de los selectores de cliente del submódulo de venta y en el select cliente del submódulo venta.